### PR TITLE
create ipsec_anchor

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -3,6 +3,7 @@ isakmpd_group: "{{ __isakmpd_group }}"
 isakmpd_service: isakmpd
 isakmpd_conf: "{{ __isakmpd_conf }}"
 isakmpd_flags: "-K"
+isakmpd_conf_dir: /etc/pf.conf.d
 
 isakmpd_addresses:
 

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -8,3 +8,6 @@
 
 - name: Reload ipsec.conf
   command: "ipsecctl -f {{ isakmpd_conf }}"
+
+- name: Reload pf anchor
+  command: "pfctl -f {{ isakmpd_conf_dir }}/ipsec_anchor.pf  -a ipsec_anchor"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -11,6 +11,19 @@
     enabled: true
   when: "{{ ansible_os_family == 'OpenBSD' }}"
 
+- name: Create a directory for anchor flagments
+  file:
+    path: "{{ isakmpd_conf_dir }}"
+    state: directory
+
+- name: Create pf anchor file
+  template:
+    src: pf.conf.anchor.j2
+    dest: "{{ isakmpd_conf_dir }}/ipsec_anchor.pf"
+    mode: 0600
+    validate: "pfctl -n -f %s -a ipsec"
+  notify: Reload pf anchor
+
 - name: Create ipsec.conf
   template:
     src: ipsec.conf.j2

--- a/templates/pf.conf.anchor.j2
+++ b/templates/pf.conf.anchor.j2
@@ -1,0 +1,7 @@
+isakmpd_me = "{{ isakmpd_addresses['me'] }}"
+pass in quick on egress proto udp from $isakmpd_me to <ipsec_peers> port { 500, 4500 }
+{% for k in isakmpd_flows %}
+{% if isakmpd_flows[k].type == 'l2tp' %}
+pass in quick on egress proto udp from $isakmpd_me to any port { 500, 4500 }
+{% endif %}
+{% endfor %}


### PR DESCRIPTION
ipsec_anchor passes UDP 500 (IPSec) and 4500 (NAT-T) traffic between the
peers. If L2TP flow found in ipsec.conf, create same rule but from any.

usage:

  # in pf.conf
  anchor ipsec_anchor
